### PR TITLE
TsunamiParserClassの修正

### DIFF
--- a/src/main/java/jp/ac/aiit/pbl/SeismicEpicenter.java
+++ b/src/main/java/jp/ac/aiit/pbl/SeismicEpicenter.java
@@ -1,4 +1,4 @@
-package jp.ac.aiit.pbl.disaster.hypocenter;
+package jp.ac.aiit.pbl;
 
 import java.util.Arrays;
 

--- a/src/main/java/jp/ac/aiit/pbl/disaster/earthquakeearlywarning/EarthquakeEarlyWarning.java
+++ b/src/main/java/jp/ac/aiit/pbl/disaster/earthquakeearlywarning/EarthquakeEarlyWarning.java
@@ -1,7 +1,7 @@
 package jp.ac.aiit.pbl.disaster.earthquakeearlywarning;
 
 import jp.ac.aiit.pbl.*;
-import jp.ac.aiit.pbl.disaster.hypocenter.SeismicEpicenter;
+import jp.ac.aiit.pbl.SeismicEpicenter;
 import java.time.LocalDateTime;
 import java.util.List;
 

--- a/src/main/java/jp/ac/aiit/pbl/disaster/earthquakeearlywarning/EarthquakeEarlyWarningParser.java
+++ b/src/main/java/jp/ac/aiit/pbl/disaster/earthquakeearlywarning/EarthquakeEarlyWarningParser.java
@@ -2,7 +2,7 @@ package jp.ac.aiit.pbl.disaster.earthquakeearlywarning;
 
 import jp.ac.aiit.pbl.Notification;
 import jp.ac.aiit.pbl.PrefixParser;
-import jp.ac.aiit.pbl.disaster.hypocenter.SeismicEpicenter;
+import jp.ac.aiit.pbl.SeismicEpicenter;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;

--- a/src/main/java/jp/ac/aiit/pbl/disaster/hypocenter/Hypocenter.java
+++ b/src/main/java/jp/ac/aiit/pbl/disaster/hypocenter/Hypocenter.java
@@ -1,6 +1,7 @@
 package jp.ac.aiit.pbl.disaster.hypocenter;
 
 import jp.ac.aiit.pbl.*;
+import jp.ac.aiit.pbl.SeismicEpicenter;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/jp/ac/aiit/pbl/disaster/hypocenter/HypocenterParser.java
+++ b/src/main/java/jp/ac/aiit/pbl/disaster/hypocenter/HypocenterParser.java
@@ -3,6 +3,7 @@ package jp.ac.aiit.pbl.disaster.hypocenter;
 import jp.ac.aiit.pbl.DisasterParser;
 import jp.ac.aiit.pbl.Notification;
 import jp.ac.aiit.pbl.PrefixParser;
+import jp.ac.aiit.pbl.SeismicEpicenter;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;

--- a/src/main/java/jp/ac/aiit/pbl/disaster/seismicIntensity/SeismicIntensityParser.java
+++ b/src/main/java/jp/ac/aiit/pbl/disaster/seismicIntensity/SeismicIntensityParser.java
@@ -1,6 +1,7 @@
 package jp.ac.aiit.pbl.disaster.seismicIntensity;
 
 import jp.ac.aiit.pbl.DisasterParser;
+import jp.ac.aiit.pbl.Prefix;
 import jp.ac.aiit.pbl.PrefixParser;
 
 import java.time.LocalDateTime;

--- a/src/main/java/jp/ac/aiit/pbl/disaster/tsunami/ExpectedTsunamiArrivalTime.java
+++ b/src/main/java/jp/ac/aiit/pbl/disaster/tsunami/ExpectedTsunamiArrivalTime.java
@@ -1,0 +1,25 @@
+package jp.ac.aiit.pbl.disaster.tsunami;
+
+import java.time.LocalDateTime;
+
+public class ExpectedTsunamiArrivalTime {
+    
+    public LocalDateTime getReachTimeToRegion(LocalDateTime reportTime, int day, int hour, int minute){
+        LocalDateTime issueDate;
+        int year = reportTime.getYear();
+        issueDate = reportTime.plusDays(day);
+        
+        if (hour == 31){
+            year = 9999;
+            hour = 0;
+            minute = 0;
+        }
+        if (minute == 63){
+            year = 9999;
+            hour = 0;
+            minute = 0;
+        }
+        return LocalDateTime.of(year, issueDate.getMonth(), issueDate.getDayOfMonth(),hour , minute);
+    }
+    
+}

--- a/src/main/java/jp/ac/aiit/pbl/disaster/tsunami/Tsunami.java
+++ b/src/main/java/jp/ac/aiit/pbl/disaster/tsunami/Tsunami.java
@@ -1,0 +1,67 @@
+package jp.ac.aiit.pbl.disaster.tsunami;
+
+import jp.ac.aiit.pbl.*;
+import jp.ac.aiit.pbl.disaster.seismicIntensity.Warning;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class Tsunami implements Disaster {
+    private Prefix prefix;
+    private List<Notification> notifications;
+    private WarningCode warningCode;
+    private List<TsunamiRegion> tsunamiRegions;
+
+    public Prefix getPrefix() {
+        return prefix;
+    }
+    
+    public void setPrefix(Prefix prefix) {
+        this.prefix = prefix;
+    }
+    
+    public List<Notification> getNotifications() {
+        return notifications;
+    }
+    
+    public void setNotifications(List<Notification> notifications) {
+        this.notifications = notifications;
+    }
+    
+    public WarningCode getWarningCode() {
+        return warningCode;
+    }
+    
+    public void setWarningCode(WarningCode warningCode) {
+        this.warningCode = warningCode;
+    }
+    
+    public List<TsunamiRegion> getTsunamiRegions() {
+        return tsunamiRegions;
+    }
+    
+    public void setTsunamiRegions(List<TsunamiRegion> tsunamiRegions) {
+        this.tsunamiRegions = tsunamiRegions;
+    }
+    
+    
+    @Override
+    public MessageType getMessageType() {
+        return null;
+    }
+    
+    @Override
+    public DisasterCategory getDisasterCategory() {
+        return null;
+    }
+    
+    @Override
+    public String toString() {
+        return "Tsunami{" +
+                "prefix=" + prefix +
+                ", notifications=" + notifications +
+                ", warningCode=" + warningCode +
+                ", tsunamiRegions=" + tsunamiRegions +
+                '}';
+    }
+}

--- a/src/main/java/jp/ac/aiit/pbl/disaster/tsunami/TsunamiForecastRegion.java
+++ b/src/main/java/jp/ac/aiit/pbl/disaster/tsunami/TsunamiForecastRegion.java
@@ -1,0 +1,36 @@
+package jp.ac.aiit.pbl.disaster.tsunami;
+
+import java.util.Arrays;
+
+public enum TsunamiForecastRegion {
+    
+    HokkaidoPacificCoastEast(100, "北海道太平洋沿岸東部"),
+    HokkaidoPacificCoastCentral(101, "北海道太平洋沿岸中部"),
+    HokkaidoPacificCoastWest(102, "北海道太平洋沿岸西部"),
+    HokkaidoJapanCoastNorth(110, "北海道日本海沿岸北部"),
+    HokkaidoJapanCoastSouth(111, "北海道日本海沿岸南部"),
+    OkhotskCoast(120, "オホーツク海沿岸"),
+    HokkaidoPacificCoast(191, "北海道太平洋沿岸"),
+    HokkaidoJapanCoast(192, "北海道日本海沿岸"),
+    OkhotskCoast2(193, "オホーツク海沿岸"),
+    AomoriJapanCoast(200, "青森県日本海沿岸"),
+    AomoriPacificCoast(201, "青森県太平洋沿岸");
+    
+    private int code;
+    private String regionName;
+    
+    private TsunamiForecastRegion(int code, String regionName){
+        this.code = code;
+        this.regionName = regionName;
+    }
+    public Integer getCode(){
+        return this.code;
+    }
+    
+    public static TsunamiForecastRegion getRegionName(int code){
+        return Arrays.stream(TsunamiForecastRegion.values())
+                .filter(data -> data.getCode().equals(code))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/src/main/java/jp/ac/aiit/pbl/disaster/tsunami/TsunamiHeight.java
+++ b/src/main/java/jp/ac/aiit/pbl/disaster/tsunami/TsunamiHeight.java
@@ -1,0 +1,34 @@
+package jp.ac.aiit.pbl.disaster.tsunami;
+
+import java.util.Arrays;
+
+public enum TsunamiHeight {
+    
+    HeightLessThan2m(1, "0.2m 未満"),
+    Height1m(2, "1m"),
+    Height3m(3, "3m"),
+    Height5m(4, "5m"),
+    Height10m(5, "10m"),
+    HeightOver10m(6, "10m超"),
+    HeightUnknown(14, "不明"),
+    OtherTsunamiHeights(15, "その他の津波の高さ");
+    
+    private int code;
+    private String tsunamiHeight;
+    
+    private TsunamiHeight(int code, String tsunamiHeight){
+        this.code = code;
+        this.tsunamiHeight = tsunamiHeight;
+    }
+    
+    public Integer getCode(){
+        return this.code;
+    }
+    
+    public static TsunamiHeight getTsunamiHeight(int code){
+        return Arrays.stream(TsunamiHeight.values())
+                .filter(data -> data.getCode().equals(code))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/src/main/java/jp/ac/aiit/pbl/disaster/tsunami/TsunamiParser.java
+++ b/src/main/java/jp/ac/aiit/pbl/disaster/tsunami/TsunamiParser.java
@@ -25,10 +25,10 @@ public class TsunamiParser implements DisasterParser{
         
         List<TsunamiRegion> tsunamiRegions = new ArrayList<>();
         
-        ExpectedTsunamiArrivalTime expectedTsunamiTime = new ExpectedTsunamiArrivalTime();
+        ExpectedTsunamiArrivalTime tsunamiForecast = new ExpectedTsunamiArrivalTime();
         
         tsunamiRegions.add(new TsunamiRegion(
-                expectedTsunamiTime.getReachTimeToRegion(
+                tsunamiForecast.getReachTimeToRegion(
                         tsunami.getPrefix().getReportTime(), //IssueDate
                         Integer.parseInt(qzMessage.substring(84, 85), 2), //day
                         Integer.parseInt(qzMessage.substring(85, 90),2),  //hour
@@ -37,7 +37,7 @@ public class TsunamiParser implements DisasterParser{
                 Integer.parseInt(qzMessage.substring(100, 110),2)));
         
         tsunamiRegions.add(new TsunamiRegion(
-                expectedTsunamiTime.getReachTimeToRegion(
+                tsunamiForecast.getReachTimeToRegion(
                         tsunami.getPrefix().getReportTime(),
                         Integer.parseInt(qzMessage.substring(110, 111), 2), //day
                         Integer.parseInt(qzMessage.substring(111, 116),2),  //hour
@@ -46,7 +46,7 @@ public class TsunamiParser implements DisasterParser{
                 Integer.parseInt(qzMessage.substring(126, 136),2)));
         
         tsunamiRegions.add(new TsunamiRegion(
-                expectedTsunamiTime.getReachTimeToRegion(
+                tsunamiForecast.getReachTimeToRegion(
                         tsunami.getPrefix().getReportTime(),
                         Integer.parseInt(qzMessage.substring(136, 137), 2), //day
                         Integer.parseInt(qzMessage.substring(137, 142),2),  //hour
@@ -55,7 +55,7 @@ public class TsunamiParser implements DisasterParser{
                 Integer.parseInt(qzMessage.substring(152, 162),2)));
         
         tsunamiRegions.add(new TsunamiRegion(
-                expectedTsunamiTime.getReachTimeToRegion(
+                tsunamiForecast.getReachTimeToRegion(
                         tsunami.getPrefix().getReportTime(),
                         Integer.parseInt(qzMessage.substring(162, 163), 2), //day
                         Integer.parseInt(qzMessage.substring(163, 168),2),  //hour
@@ -64,7 +64,7 @@ public class TsunamiParser implements DisasterParser{
                 Integer.parseInt(qzMessage.substring(178, 188),2)));
         
         tsunamiRegions.add(new TsunamiRegion(
-                expectedTsunamiTime.getReachTimeToRegion(
+                tsunamiForecast.getReachTimeToRegion(
                         tsunami.getPrefix().getReportTime(),
                         Integer.parseInt(qzMessage.substring(188, 189), 2), //day
                         Integer.parseInt(qzMessage.substring(189, 194),2),  //hour

--- a/src/main/java/jp/ac/aiit/pbl/disaster/tsunami/TsunamiParser.java
+++ b/src/main/java/jp/ac/aiit/pbl/disaster/tsunami/TsunamiParser.java
@@ -25,8 +25,10 @@ public class TsunamiParser implements DisasterParser{
         
         List<TsunamiRegion> tsunamiRegions = new ArrayList<>();
         
+        ExpectedTsunamiArrivalTime expectedTsunamiTime = new ExpectedTsunamiArrivalTime();
+        
         tsunamiRegions.add(new TsunamiRegion(
-                expectedTsunamiArrivalTime(
+                expectedTsunamiTime.getReachTimeToRegion(
                         tsunami.getPrefix().getReportTime(), //IssueDate
                         Integer.parseInt(qzMessage.substring(84, 85), 2), //day
                         Integer.parseInt(qzMessage.substring(85, 90),2),  //hour
@@ -35,7 +37,7 @@ public class TsunamiParser implements DisasterParser{
                 Integer.parseInt(qzMessage.substring(100, 110),2)));
         
         tsunamiRegions.add(new TsunamiRegion(
-                expectedTsunamiArrivalTime(
+                expectedTsunamiTime.getReachTimeToRegion(
                         tsunami.getPrefix().getReportTime(),
                         Integer.parseInt(qzMessage.substring(110, 111), 2), //day
                         Integer.parseInt(qzMessage.substring(111, 116),2),  //hour
@@ -44,7 +46,7 @@ public class TsunamiParser implements DisasterParser{
                 Integer.parseInt(qzMessage.substring(126, 136),2)));
         
         tsunamiRegions.add(new TsunamiRegion(
-                expectedTsunamiArrivalTime(
+                expectedTsunamiTime.getReachTimeToRegion(
                         tsunami.getPrefix().getReportTime(),
                         Integer.parseInt(qzMessage.substring(136, 137), 2), //day
                         Integer.parseInt(qzMessage.substring(137, 142),2),  //hour
@@ -53,7 +55,7 @@ public class TsunamiParser implements DisasterParser{
                 Integer.parseInt(qzMessage.substring(152, 162),2)));
         
         tsunamiRegions.add(new TsunamiRegion(
-                expectedTsunamiArrivalTime(
+                expectedTsunamiTime.getReachTimeToRegion(
                         tsunami.getPrefix().getReportTime(),
                         Integer.parseInt(qzMessage.substring(162, 163), 2), //day
                         Integer.parseInt(qzMessage.substring(163, 168),2),  //hour
@@ -62,7 +64,7 @@ public class TsunamiParser implements DisasterParser{
                 Integer.parseInt(qzMessage.substring(178, 188),2)));
         
         tsunamiRegions.add(new TsunamiRegion(
-                expectedTsunamiArrivalTime(
+                expectedTsunamiTime.getReachTimeToRegion(
                         tsunami.getPrefix().getReportTime(),
                         Integer.parseInt(qzMessage.substring(188, 189), 2), //day
                         Integer.parseInt(qzMessage.substring(189, 194),2),  //hour
@@ -72,22 +74,5 @@ public class TsunamiParser implements DisasterParser{
         tsunami.setTsunamiRegions(tsunamiRegions);
         
         return tsunami;
-    }
-    private LocalDateTime expectedTsunamiArrivalTime(LocalDateTime reportTime, int day, int hour, int minute){
-        LocalDateTime issueDate;
-        int year = reportTime.getYear();
-        issueDate = reportTime.plusDays(day);
-        
-        if (hour == 31){
-            year = 9999;
-            hour = 0;
-            minute = 0;
-        }
-        if (minute == 63){
-            year = 9999;
-            hour = 0;
-            minute = 0;
-        }
-        return LocalDateTime.of(year, issueDate.getMonth(), issueDate.getDayOfMonth(),hour , minute);
     }
 }

--- a/src/main/java/jp/ac/aiit/pbl/disaster/tsunami/TsunamiParser.java
+++ b/src/main/java/jp/ac/aiit/pbl/disaster/tsunami/TsunamiParser.java
@@ -1,0 +1,93 @@
+package jp.ac.aiit.pbl.disaster.tsunami;
+
+import jp.ac.aiit.pbl.DisasterParser;
+import jp.ac.aiit.pbl.Notification;
+import jp.ac.aiit.pbl.Prefix;
+import jp.ac.aiit.pbl.PrefixParser;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TsunamiParser implements DisasterParser{
+    
+    public Tsunami parse(String qzMessage){
+        Tsunami tsunami = new Tsunami();
+        PrefixParser prefixParser = new PrefixParser();
+        tsunami.setPrefix(prefixParser.parse(qzMessage));
+        
+        List<Notification> notifications = new ArrayList<>();
+        notifications.add(Notification.getNotificationContent(Integer.parseInt(qzMessage.substring(53, 62),2)));
+        notifications.add(Notification.getNotificationContent(Integer.parseInt(qzMessage.substring(62, 71),2)));
+        notifications.add(Notification.getNotificationContent(Integer.parseInt(qzMessage.substring(71, 80),2)));
+        tsunami.setNotifications(notifications);
+        
+        tsunami.setWarningCode(WarningCode.getTsunamiAlarmType(Integer.parseInt(qzMessage.substring(80, 84),2)));
+        
+        List<TsunamiRegion> tsunamiRegions = new ArrayList<>();
+        
+        tsunamiRegions.add(new TsunamiRegion(
+                expectedTsunamiArrivalTime(
+                        tsunami.getPrefix().getReportTime(), //IssueDate
+                        Integer.parseInt(qzMessage.substring(84, 85), 2), //day
+                        Integer.parseInt(qzMessage.substring(85, 90),2),  //hour
+                        Integer.parseInt(qzMessage.substring(90, 96), 2)), //minute
+                Integer.parseInt(qzMessage.substring(96, 100), 2),
+                Integer.parseInt(qzMessage.substring(100, 110),2)));
+        
+        tsunamiRegions.add(new TsunamiRegion(
+                expectedTsunamiArrivalTime(
+                        tsunami.getPrefix().getReportTime(),
+                        Integer.parseInt(qzMessage.substring(110, 111), 2), //day
+                        Integer.parseInt(qzMessage.substring(111, 116),2),  //hour
+                        Integer.parseInt(qzMessage.substring(116, 122), 2)), //minute
+                Integer.parseInt(qzMessage.substring(122, 126), 2),
+                Integer.parseInt(qzMessage.substring(126, 136),2)));
+        
+        tsunamiRegions.add(new TsunamiRegion(
+                expectedTsunamiArrivalTime(
+                        tsunami.getPrefix().getReportTime(),
+                        Integer.parseInt(qzMessage.substring(136, 137), 2), //day
+                        Integer.parseInt(qzMessage.substring(137, 142),2),  //hour
+                        Integer.parseInt(qzMessage.substring(142, 148), 2)), //minute
+                Integer.parseInt(qzMessage.substring(148, 152), 2),
+                Integer.parseInt(qzMessage.substring(152, 162),2)));
+        
+        tsunamiRegions.add(new TsunamiRegion(
+                expectedTsunamiArrivalTime(
+                        tsunami.getPrefix().getReportTime(),
+                        Integer.parseInt(qzMessage.substring(162, 163), 2), //day
+                        Integer.parseInt(qzMessage.substring(163, 168),2),  //hour
+                        Integer.parseInt(qzMessage.substring(168, 174), 2)), //minute
+                Integer.parseInt(qzMessage.substring(174, 178), 2),
+                Integer.parseInt(qzMessage.substring(178, 188),2)));
+        
+        tsunamiRegions.add(new TsunamiRegion(
+                expectedTsunamiArrivalTime(
+                        tsunami.getPrefix().getReportTime(),
+                        Integer.parseInt(qzMessage.substring(188, 189), 2), //day
+                        Integer.parseInt(qzMessage.substring(189, 194),2),  //hour
+                        Integer.parseInt(qzMessage.substring(194, 200), 2)), //minute
+                Integer.parseInt(qzMessage.substring(200, 204), 2),
+                Integer.parseInt(qzMessage.substring(204, 214),2)));
+        tsunami.setTsunamiRegions(tsunamiRegions);
+        
+        return tsunami;
+    }
+    private LocalDateTime expectedTsunamiArrivalTime(LocalDateTime reportTime, int day, int hour, int minute){
+        LocalDateTime issueDate;
+        int year = reportTime.getYear();
+        issueDate = reportTime.plusDays(day);
+        
+        if (hour == 31){
+            year = 9999;
+            hour = 0;
+            minute = 0;
+        }
+        if (minute == 63){
+            year = 9999;
+            hour = 0;
+            minute = 0;
+        }
+        return LocalDateTime.of(year, issueDate.getMonth(), issueDate.getDayOfMonth(),hour , minute);
+    }
+}

--- a/src/main/java/jp/ac/aiit/pbl/disaster/tsunami/TsunamiRegion.java
+++ b/src/main/java/jp/ac/aiit/pbl/disaster/tsunami/TsunamiRegion.java
@@ -26,6 +26,7 @@ public class TsunamiRegion {
         return expectedArrivalDate;
     }
     
+    
     @Override
     public String toString() {
         return "{" +

--- a/src/main/java/jp/ac/aiit/pbl/disaster/tsunami/TsunamiRegion.java
+++ b/src/main/java/jp/ac/aiit/pbl/disaster/tsunami/TsunamiRegion.java
@@ -1,0 +1,37 @@
+package jp.ac.aiit.pbl.disaster.tsunami;
+
+import java.time.LocalDateTime;
+
+public class TsunamiRegion {
+    
+    private LocalDateTime expectedArrivalDate;
+    private TsunamiHeight tsunamiHeight;
+    private TsunamiForecastRegion tsunamiForecastRegion;
+    
+    TsunamiRegion(LocalDateTime expectedArrivalDate, int tsunamiHeightCode, int tsunamiForecastRegionCode){
+        this.expectedArrivalDate = expectedArrivalDate;
+        this.tsunamiForecastRegion = TsunamiForecastRegion.getRegionName(tsunamiForecastRegionCode);
+        this.tsunamiHeight = TsunamiHeight.getTsunamiHeight(tsunamiHeightCode);
+    }
+    
+    public TsunamiHeight getTsunamiHeight() {
+        return tsunamiHeight;
+    }
+    
+    public TsunamiForecastRegion getTsunamiForecastRegion() {
+        return tsunamiForecastRegion;
+    }
+    
+    public LocalDateTime getExpectedArrivalDate() {
+        return expectedArrivalDate;
+    }
+    
+    @Override
+    public String toString() {
+        return "{" +
+                "expectedArrivalDate=" + expectedArrivalDate +
+                ", tsunamiHeight=" + tsunamiHeight +
+                ", tsunamiForecastRegion=" + tsunamiForecastRegion +
+                '}';
+    }
+}

--- a/src/main/java/jp/ac/aiit/pbl/disaster/tsunami/WarningCode.java
+++ b/src/main/java/jp/ac/aiit/pbl/disaster/tsunami/WarningCode.java
@@ -1,0 +1,30 @@
+package jp.ac.aiit.pbl.disaster.tsunami;
+
+import java.util.Arrays;
+
+public enum WarningCode {
+    
+    NoTsunami(1, "津波なし"),
+    AlarmRelease(2, "警報解除"),
+    TsunamiWarning(3, "津波警報"),
+    BigTsunamiWarning(4, "大津波警報"),
+    BigTsunamiWarningAnnouncement(5, "大津波警報:発表"),
+    OtherAlarms(15, "その他の警報");
+    
+    private int code;
+    private String alarmType;
+    
+    private WarningCode(int code, String alarmType){
+        this.code = code;
+        this.alarmType = alarmType;
+    }
+    public Integer getCode(){
+        return this.code;
+    }
+    public static WarningCode getTsunamiAlarmType(int code){
+        return Arrays.stream(WarningCode.values())
+                .filter(data -> data.getCode().equals(code))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/src/test/java/jp/ac/aiit/pbl/disaster/earthquakeearlywarning/earthquakeEarlyWarningTest.java
+++ b/src/test/java/jp/ac/aiit/pbl/disaster/earthquakeearlywarning/earthquakeEarlyWarningTest.java
@@ -1,7 +1,7 @@
 package jp.ac.aiit.pbl.disaster.earthquakeearlywarning;
 
 import jp.ac.aiit.pbl.Notification;
-import jp.ac.aiit.pbl.disaster.hypocenter.SeismicEpicenter;
+import jp.ac.aiit.pbl.SeismicEpicenter;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/jp/ac/aiit/pbl/disaster/hypocenter/HypocenterParserTest.java
+++ b/src/test/java/jp/ac/aiit/pbl/disaster/hypocenter/HypocenterParserTest.java
@@ -16,7 +16,6 @@ public class HypocenterParserTest {
         Hypocenter hypocenter = hypocenterParser.parse("1100011010101101111100101100010100010110100000000000000110010100110011000110011101011000100011101111101011100101000000101111011001111011111011010110011111011111011");
         System.out.println(hypocenter);
         
-        System.out.println(hypocenter.getPrefix());
     }
     
     /**

--- a/src/test/java/jp/ac/aiit/pbl/disaster/hypocenter/SeismicEpicenterTest.java
+++ b/src/test/java/jp/ac/aiit/pbl/disaster/hypocenter/SeismicEpicenterTest.java
@@ -1,6 +1,6 @@
 package jp.ac.aiit.pbl.disaster.hypocenter;
 
-import jp.ac.aiit.pbl.disaster.hypocenter.SeismicEpicenter;
+import jp.ac.aiit.pbl.SeismicEpicenter;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/jp/ac/aiit/pbl/disaster/tsunami/TsunamiForecastRegionTest.java
+++ b/src/test/java/jp/ac/aiit/pbl/disaster/tsunami/TsunamiForecastRegionTest.java
@@ -1,0 +1,97 @@
+package jp.ac.aiit.pbl.disaster.tsunami;
+
+import org.junit.Test;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+public class TsunamiForecastRegionTest {
+    
+    /**
+     * code100(regionName:HokkaidoPacificCoastEast)
+     */
+    @Test
+    public void inCaseOfValueIs100CanGetHokkaidoPacificCoastEast(){
+        assertThat(TsunamiForecastRegion.HokkaidoPacificCoastEast, is(TsunamiForecastRegion.getRegionName(100)));
+    }
+    
+    /**
+     * code101(regionName:HokkaidoPacificCoastCentral)
+     */
+    @Test
+    public void inCaseOfValueIs101CanGetHokkaidoPacificCoastCentral(){
+        assertThat(TsunamiForecastRegion.HokkaidoPacificCoastCentral, is(TsunamiForecastRegion.getRegionName(101)));
+    }
+    
+    /**
+     * code102(regionName:HokkaidoPacificCoastWest)
+     */
+    @Test
+    public void inCaseOfValueIs102CanGetHokkaidoPacificCoastWest(){
+        assertThat(TsunamiForecastRegion.HokkaidoPacificCoastWest, is(TsunamiForecastRegion.getRegionName(102)));
+    }
+    
+    /**
+     * code110(regionName:HokkaidoJapanCoastNorth)
+     */
+    @Test
+    public void inCaseOfValueIs110CanGetHokkaidoJapanCoastNorth(){
+        assertThat(TsunamiForecastRegion.HokkaidoJapanCoastNorth, is(TsunamiForecastRegion.getRegionName(110)));
+    }
+    
+    /**
+     * code111(regionName:HokkaidoJapanCoastSouth)
+     */
+    @Test
+    public void inCaseOfValueIs111CanGetHokkaidoJapanCoastSouth(){
+        assertThat(TsunamiForecastRegion.HokkaidoJapanCoastSouth, is(TsunamiForecastRegion.getRegionName(111)));
+    }
+    
+    /**
+     * code120(regionName:OkhotskCoast)
+     */
+    @Test
+    public void inCaseOfValueIs120CanGetOkhotskCoast(){
+        assertThat(TsunamiForecastRegion.OkhotskCoast, is(TsunamiForecastRegion.getRegionName(120)));
+    }
+    
+    /**
+     * code191(regionName:HokkaidoPacificCoast)
+     */
+    @Test
+    public void inCaseOfValueIs191CanGetHokkaidoPacificCoast(){
+        assertThat(TsunamiForecastRegion.HokkaidoPacificCoast, is(TsunamiForecastRegion.getRegionName(191)));
+    }
+    
+    /**
+     * code192(regionName:HokkaidoJapanCoast)
+     */
+    @Test
+    public void inCaseOfValueIs192CanGetHokkaidoJapanCoast(){
+        assertThat(TsunamiForecastRegion.HokkaidoJapanCoast, is(TsunamiForecastRegion.getRegionName(192)));
+    }
+    
+    /**
+     * code193(regionName:OkhotskCoast)
+     */
+    @Test
+    public void inCaseOfValueIs193CanGetOkhotskCoast2(){
+        assertThat(TsunamiForecastRegion.OkhotskCoast2, is(TsunamiForecastRegion.getRegionName(193)));
+    }
+    
+    /**
+     * code200(regionName:AomoriJapanCoast)
+     */
+    @Test
+    public void inCaseOfValueIs200CanGetAomoriJapanCoast(){
+        assertThat(TsunamiForecastRegion.AomoriJapanCoast, is(TsunamiForecastRegion.getRegionName(200)));
+    }
+    
+    /**
+     * code201(regionName:AomoriPacificCoast)
+     */
+    @Test
+    public void inCaseOfValueIs201CanGetAomoriPacificCoast(){
+        assertThat(TsunamiForecastRegion.AomoriPacificCoast, is(TsunamiForecastRegion.getRegionName(201)));
+    }
+
+}

--- a/src/test/java/jp/ac/aiit/pbl/disaster/tsunami/TsunamiHeightTest.java
+++ b/src/test/java/jp/ac/aiit/pbl/disaster/tsunami/TsunamiHeightTest.java
@@ -1,0 +1,66 @@
+package jp.ac.aiit.pbl.disaster.tsunami;
+
+import org.junit.Test;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+public class TsunamiHeightTest {
+    
+    /**
+     * code1(tsunamiHeight:0.2m 未満)
+     */
+    @Test
+    public void inCaseOfValueIs1CanGetHeightLessThan2m(){
+        assertThat(TsunamiHeight.HeightLessThan2m, is(TsunamiHeight.getTsunamiHeight(1)));
+    }
+    /**
+     * code2(tsunamiHeight:1m)
+     */
+    @Test
+    public void inCaseOfValueIs2CanGetHeight1m(){
+        assertThat(TsunamiHeight.Height1m, is(TsunamiHeight.getTsunamiHeight(2)));
+    }
+    /**
+     * code3(tsunamiHeight:3m)
+     */
+    @Test
+    public void inCaseOfValueIs3CanGetHeight3m(){
+        assertThat(TsunamiHeight.Height3m, is(TsunamiHeight.getTsunamiHeight(3)));
+    }
+    /**
+     * code4(tsunamiHeight:5m)
+     */
+    @Test
+    public void inCaseOfValueIs4CanGetHeight5m(){
+        assertThat(TsunamiHeight.Height5m, is(TsunamiHeight.getTsunamiHeight(4)));
+    }
+    /**
+     * code5(tsunamiHeight:10m)
+     */
+    @Test
+    public void inCaseOfValueIs5CanGetHeight10m(){
+        assertThat(TsunamiHeight.Height10m, is(TsunamiHeight.getTsunamiHeight(5)));
+    }
+    /**
+     * code6(tsunamiHeight:Over10m)
+     */
+    @Test
+    public void inCaseOfValueIs6CanGetHeightOver10m(){
+        assertThat(TsunamiHeight.HeightOver10m, is(TsunamiHeight.getTsunamiHeight(6)));
+    }
+    /**
+     * code14(tsunamiHeight:Unknown)
+     */
+    @Test
+    public void inCaseOfValueIs14CanGetHeightUnknown(){
+        assertThat(TsunamiHeight.HeightUnknown, is(TsunamiHeight.getTsunamiHeight(14)));
+    }
+    /**
+     * code15(tsunamiHeight:OtherTsunamiHeights)
+     */
+    @Test
+    public void inCaseOfValueIs15CanGetOtherTsunamiHeights(){
+        assertThat(TsunamiHeight.OtherTsunamiHeights, is(TsunamiHeight.getTsunamiHeight(15)));
+    }
+    
+}

--- a/src/test/java/jp/ac/aiit/pbl/disaster/tsunami/TsunamiParserTest.java
+++ b/src/test/java/jp/ac/aiit/pbl/disaster/tsunami/TsunamiParserTest.java
@@ -1,0 +1,109 @@
+package jp.ac.aiit.pbl.disaster.tsunami;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class TsunamiParserTest {
+    
+    @Test
+    public void tsunamiParserTest(){
+        TsunamiParser tsunamiParser = new TsunamiParser();
+        Tsunami tsunami = tsunamiParser.parse(
+                "110001101010110111110010110001010001011010000000000000011001010011001100011001111111011111111111111100011001001101111111111111000110010011011111101111110001100100" +
+                        "1101111110111111000110010011011111101111110001100100");
+        
+        System.out.println(tsunami);
+    }
+    /**
+     * (day:0) -> sameday as the Issueday
+     */
+    @Test
+    public void inCaseOfValueOfDayIs0CanGetSameDateOfIssueDate(){
+        TsunamiParser tsunamiParser = new TsunamiParser();
+        Tsunami tsunami = tsunamiParser.parse("110001101010110111110010110001010001011010000000000000011001010011001100011001111111011111111111111100011001001101111111111111000110010011011111101111110001100100" +
+                "1101111110111111000110010011011111101111110001100100");
+        assertThat(tsunami.getTsunamiRegions().get(0).getExpectedArrivalDate().getDayOfMonth(), is(17));
+    }
+    /**
+     * (day:1) -> Nextday after the Issueday
+     */
+    @Test
+    public void inCaseOfValueOfDayIs1CanGetNextDateOfIssueDate(){
+        TsunamiParser tsunamiParser = new TsunamiParser();
+        Tsunami tsunami = tsunamiParser.parse("110001101010110111110010110001010001011010000000000000011001010011001100011001111111011111111111111100011001001101111111111111000110010011011111101111110001100100" +
+                "1101111110111111000110010011011111101111110001100100");
+        assertThat(tsunami.getTsunamiRegions().get(1).getExpectedArrivalDate().getDayOfMonth(), is(18));
+    }
+    /**
+     * (hour:0 or minute:0) -> Year is 9999, UnknownNumber
+     */
+    @Test
+    public void inCaseOfUnknownNumberOfHourCanGetUnknownYear(){
+        TsunamiParser tsunamiParser = new TsunamiParser();
+        Tsunami tsunami = tsunamiParser.parse("110001101010110111110010110001010001011010000000000000011001010011001100011001111111011111111111111100011001001101111111111111000110010011011111101111110001100100" +
+                "1101111110111111000110010011011111101111110001100100");
+        assertThat(tsunami.getTsunamiRegions().get(0).getExpectedArrivalDate().getYear(), is(9999));
+    }
+    /**
+     * (hour:0) -> Hour is 0, UnknownNumber
+     */
+    @Test
+    public void inCaseOfUnknownHourCanGetUnknownHour(){
+        TsunamiParser tsunamiParser = new TsunamiParser();
+        Tsunami tsunami = tsunamiParser.parse("110001101010110111110010110001010001011010000000000000011001010011001100011001111111011111111111111100011001001101111111111111000110010011011111101111110001100100" +
+                "1101111110111111000110010011011111101111110001100100");
+        assertThat(tsunami.getTsunamiRegions().get(0).getExpectedArrivalDate().getHour(), is(0));
+    }
+    /**
+     * (hour:0-23)
+     */
+    @Test
+    public void inCaseOfValueOfHourIs23CanGetHour23(){
+        TsunamiParser tsunamiParser = new TsunamiParser();
+        Tsunami tsunami = tsunamiParser.parse("110001101010110111110010110001010001011010000000000000011001010011001100011001111111011111111111111100011001001101111111111111000110010011011111101111110001100100" +
+                "1101111110111111000110010011011111101111110001100100");
+        assertThat(tsunami.getTsunamiRegions().get(2).getExpectedArrivalDate().getHour(), is(23));
+    }
+    /**
+     * (minute:0) -> Minute is 0, UnknownNumber
+     */
+    @Test
+    public void inCaseOfUnknownMinuteCanGetUnknownMinute(){
+        TsunamiParser tsunamiParser = new TsunamiParser();
+        Tsunami tsunami = tsunamiParser.parse("110001101010110111110010110001010001011010000000000000011001010011001100011001111111011111111111111100011001001101111111111111000110010011011111101111110001100100" +
+                "1101111110111111000110010011011111101111110001100100");
+        assertThat(tsunami.getTsunamiRegions().get(0).getExpectedArrivalDate().getMinute(), is(0));
+    }
+    /**
+     * (hour:0 or minute:0) -> Year is 9999, UnknownNumber
+     */
+    @Test
+    public void inCaseOfValueOfMinuteIs0CanGetUnknownYear(){
+        TsunamiParser tsunamiParser = new TsunamiParser();
+        Tsunami tsunami = tsunamiParser.parse("110001101010110111110010110001010001011010000000000000011001010011001100011001111111011111111111111100011001001101111111111111000110010011011111101111110001100100" +
+                "1101111110111111000110010011011111101111110001100100");
+        assertThat(tsunami.getTsunamiRegions().get(0).getExpectedArrivalDate().getYear(), is(9999));
+    }
+    /**
+     * (minute:0-59)
+     */
+    @Test
+    public void inCaseOfValueOfMinuteIs59CanGetMinute59(){
+        TsunamiParser tsunamiParser = new TsunamiParser();
+        Tsunami tsunami = tsunamiParser.parse("110001101010110111110010110001010001011010000000000000011001010011001100011001111111011111111111111100011001001101111111111111000110010011011111101111110001100100" +
+                "1101111110111111000110010011011111101111110001100100");
+        assertThat(tsunami.getTsunamiRegions().get(3).getExpectedArrivalDate().getMinute(), is(59));
+    }
+    
+    @Test
+    public void tsunamiDigitTest(){
+        TsunamiParser tsunamiParser = new TsunamiParser();
+        Tsunami tsunami = tsunamiParser.parse("110001101010110111110010110001010001011010000000000000011001010011001100011001111111011111111111111100011001001101111111111111000110010011011111101111110001100100" +
+                "1101111110111111000110010011011111101111110001100100");
+        assertThat(tsunami.getNotifications().size(), is(3));
+        assertThat(tsunami.getWarningCode().getCode(), is(15));
+        assertThat(tsunami.getTsunamiRegions().size(), is(5));
+    }
+}

--- a/src/test/java/jp/ac/aiit/pbl/disaster/tsunami/WarningCodeTest.java
+++ b/src/test/java/jp/ac/aiit/pbl/disaster/tsunami/WarningCodeTest.java
@@ -1,0 +1,51 @@
+package jp.ac.aiit.pbl.disaster.tsunami;
+
+import org.junit.Test;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+public class WarningCodeTest {
+    
+    /**
+     * code1(alarmType:NoTsunami)
+     */
+    @Test
+    public void inCaseOfValueIs1CanGetNoTsunami(){
+        assertThat(WarningCode.NoTsunami, is(WarningCode.getTsunamiAlarmType(1)));
+    }
+    /**
+     * code2(alarmType:AlarmRelease)
+     */
+    @Test
+    public void inCaseOfValueIs2CanGetAlarmRelease(){
+        assertThat(WarningCode.AlarmRelease, is(WarningCode.getTsunamiAlarmType(2)));
+    }
+    /**
+     * code3(alarmType:TsunamiWarning)
+     */
+    @Test
+    public void inCaseOfValueIs3CanGetTsunamiWarning(){
+        assertThat(WarningCode.TsunamiWarning, is(WarningCode.getTsunamiAlarmType(3)));
+    }
+    /**
+     * code4(alarmType:BigTsunamiWarning)
+     */
+    @Test
+    public void inCaseOfValueIs4CanGetBigTsunamiWarning(){
+        assertThat(WarningCode.BigTsunamiWarning, is(WarningCode.getTsunamiAlarmType(4)));
+    }
+    /**
+     * code5 (alarmType:BigTsunamiWarningAnnouncement)
+     */
+    @Test
+    public void inCaseOfValueIs5CanGetBigTsunamiWarningAnnouncement(){
+        assertThat(WarningCode.BigTsunamiWarningAnnouncement, is(WarningCode.getTsunamiAlarmType(5)));
+    }
+    /**
+     * code15 (alarmType:OtherAlarms)
+     */
+    @Test
+    public void inCaseOfValueIs15canGetOtherAlarms(){
+        assertThat(WarningCode.OtherAlarms, is(WarningCode.getTsunamiAlarmType(15)));
+    }
+}


### PR DESCRIPTION
以下の内容で修正しました。
・TsunamiParserClassに記載していたgetExpectedArraivalTimeメソッドをExpectedArraivalTimeクラスへ移管
・getExpectedArraivalTimeメソッドの名前を、getReachTimeToRegionに変更
お手数ですが、確認お願いします。